### PR TITLE
fix Unexpected top-level property "plugin"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -122,7 +122,7 @@ module.exports = {
 
     configs: {
         'extension': {
-            plugin: ['gjs'],
+            plugins: ['gjs'],
             env: {
                 'es6': true,
                 'gjs/shell-extension': true
@@ -130,7 +130,7 @@ module.exports = {
             rules: GJS_RULES
         },
         'application': {
-            plugin: ['gjs'],
+            plugins: ['gjs'],
             env: {
                 'es6': true,
                 'gjs/application': true


### PR DESCRIPTION
using plugins with recommended .eslintrc.js causes eslint error:
```
Error: ESLint configuration in plugin:gjs/extension is invalid:
	- Unexpected top-level property "plugin".
```