### PR TITLE
Fix eslint 5 compatibility

### DIFF
--- a/lib/rules/translation-strings.js
+++ b/lib/rules/translation-strings.js
@@ -5,8 +5,6 @@
 
 'use strict';
 
-const astUtils = require('eslint/lib/ast-utils');
-
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -37,6 +35,10 @@ module.exports = {
                 }
             }
             return false;
+        }
+
+        function isSurroundedBy(val, character) {
+            return val[0] === character && val[val.length - 1] === character;
         }
 
         // convert: Taken from eslint/lib/rules/quotes.js
@@ -80,8 +82,8 @@ module.exports = {
 
                 if (typeof val === 'string') {
 
-                    let singleQuoted = astUtils.isSurroundedBy(rawVal, '\'');
-                    let doubleQuoted = astUtils.isSurroundedBy(rawVal, '"');
+                    let singleQuoted = isSurroundedBy(rawVal, '\'');
+                    let doubleQuoted = isSurroundedBy(rawVal, '"');
                     let translating = isTranslating(node);
 
                     if (singleQuoted && translating) {


### PR DESCRIPTION
In eslint 5, the location of the astutils file has changed. Because only
one function from that file is used, it makes sense to duplicate it,
instead of trying to import if from eslint itself, which could cause
compatibility issues with older and/or newer versions